### PR TITLE
Clarify cross-platform installation and dependency reuse

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.sh text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Added complete clone-to-launch installation instructions for Windows, macOS,
+  Ubuntu/Debian, Fedora, and Arch Linux.
+- Added a transparent Windows `install.cmd` entry point and explicit CPU/CUDA/
+  Metal runtime replacement options.
+- Documented upstream model provenance, local storage, idempotent upgrades, and
+  behavior when Python, FFmpeg, packages, models, or databases already exist.
+- Expanded environment verification with runtime versions, optional package
+  availability, data/model directories, and free disk space.
+
 ## 0.4.0 - 2026-07-26
 
 - Renamed the application and all public entry points to Meet2Notes.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ behind independent workers that can keep models resident in RAM or VRAM.
 > Meet2Notes is in active alpha development. Back up important recordings and
 > always obtain the consent required to record a conversation.
 
+<details>
+<summary><strong>Table of contents</strong></summary>
+
+- [Why Meet2Notes](#why-meet2notes)
+- [Install from zero](#install-from-zero)
+- [Managed models](#managed-models)
+- [How it works](#how-it-works)
+- [Platform support](#platform-support)
+- [Data, privacy, and migration](#data-privacy-and-migration)
+- [Development](#development)
+- [Roadmap](#roadmap)
+
+</details>
+
 ## Why Meet2Notes
 
 - **Private by default** — local server, local SQLite database, local models,
@@ -43,46 +57,59 @@ behind independent workers that can keep models resident in RAM or VRAM.
 - **Portable media import** — WAV, MP3, M4A, FLAC, OGG, AAC, MP4, MKV, WebM,
   and MOV through FFmpeg.
 
-## One-command installation
+## Install from zero
 
 The installer creates an isolated `.venv`, installs native audio and AI
 runtimes, detects a compatible llama.cpp backend, installs FFmpeg when the
 platform package manager permits it, downloads the recommended models, and
 verifies the final environment.
 
-### Windows
+### Windows 10/11
 
-Open PowerShell in the project folder:
-
-```powershell
-Set-ExecutionPolicy -Scope Process Bypass
-.\install.ps1
-.\.venv\Scripts\meet2notes.exe
-```
-
-Useful options:
+Install Git and Python 3.12, then clone and launch:
 
 ```powershell
-# Force the portable CPU build and skip the ~1.2 GiB model download
-.\install.ps1 -AiBackend cpu -Models none
+winget install --id Git.Git --exact
+winget install --id Python.Python.3.12 --exact
 
-# Install development tools and launch after setup
-.\install.ps1 -Dev -Start
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+.\install.cmd -Start
 ```
 
-### macOS or Linux
+`install.cmd` runs the readable PowerShell installer with a process-only policy
+bypass. It does not install an unsigned application binary or weaken the
+permanent PowerShell policy.
+
+### macOS
 
 ```bash
+brew install git python@3.12 ffmpeg portaudio
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
 chmod +x install.sh
-./install.sh
-.venv/bin/meet2notes
+./install.sh --start
 ```
 
-Use `./install.sh --no-models` for a runtime-only installation, or
-`./install.sh --dev --start` for a development setup that launches immediately.
+### Ubuntu/Debian
+
+```bash
+sudo apt update
+sudo apt install -y git python3 python3-venv python3-dev \
+  ffmpeg portaudio19-dev libsndfile1 build-essential cmake
+
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+chmod +x install.sh
+./install.sh --start
+```
 
 Meet2Notes opens at [http://127.0.0.1:8765](http://127.0.0.1:8765). It binds
 only to the local machine unless you explicitly change the host.
+
+See the complete [installation guide](docs/INSTALLATION.md) for Fedora, Arch,
+private-repository authentication, CUDA/Metal selection, upgrades, existing
+dependencies, and troubleshooting.
 
 ## Managed models
 
@@ -94,8 +121,13 @@ The default installation downloads and validates these local models:
 | Speaker diarization | Pyannote 3.0 int8 + 3D-Speaker | 45 MiB | sherpa-onnx |
 | Meeting summaries | LFM2.5 1.2B Q4_K_M | 700 MiB | llama.cpp |
 
-Models are downloaded into the operating system's private Meet2Notes data
-directory and reused on later runs. You can install or verify them independently:
+Model weights are **not committed to this repository**. Faster Whisper and
+LFM2.5 come directly from their publishers on Hugging Face; the two
+sherpa-onnx models come from official k2-fsa GitHub Releases. They are stored in
+the operating system's private Meet2Notes data directory and reused on later
+runs.
+
+You can install or verify them independently:
 
 ```bash
 meet2notes-models --models all
@@ -105,6 +137,11 @@ meet2notes-models --models diarization summary
 
 Downloads happen only when you run the installer, invoke `meet2notes-models`, or
 confirm an installation action in Settings.
+
+Re-running an installer is safe: it reuses `.venv`, compatible packages,
+FFmpeg/FFprobe found on `PATH`, existing models, databases, and recordings. Use
+the explicit `-ReinstallAiRuntime` or `--reinstall-ai-runtime` option only when
+replacing an existing CPU/GPU llama.cpp backend.
 
 ## How it works
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,351 @@
+# Installing Meet2Notes from zero
+
+Meet2Notes does not require an unsigned `.exe`. The source checkout contains
+readable PowerShell, Batch, and Bash installers. They create an isolated Python
+environment inside the project, install the native runtimes, download the
+selected models, and verify the result.
+
+## Before you start
+
+Recommended hardware:
+
+- 64-bit Windows 10/11, macOS, or a current 64-bit Linux distribution.
+- 8 GiB RAM minimum; 16 GiB recommended for transcription plus summaries.
+- About 4 GiB free for the environment, models, caches, and initial recordings.
+- Python 3.12 recommended. Python 3.11 and 3.13 are supported, but current
+  prebuilt llama.cpp CUDA wheels are available only for Python 3.10-3.12.
+- An internet connection is needed for the initial package and model download.
+  Meetings can be processed locally afterward.
+
+This repository is currently private. The GitHub account cloning it must have
+access. Git Credential Manager normally opens a browser sign-in when HTTPS
+authentication is required.
+
+## Windows 10/11
+
+### 1. Install Git and Python
+
+Open a normal PowerShell window. Administrator mode is usually unnecessary:
+
+```powershell
+winget install --id Git.Git --exact
+winget install --id Python.Python.3.12 --exact
+```
+
+Close and reopen PowerShell so the new commands are visible:
+
+```powershell
+git --version
+py -3.12 --version
+```
+
+If `winget` is unavailable, install
+[Git for Windows](https://git-scm.com/download/win) and
+[Python 3.12](https://www.python.org/downloads/) from their official sites.
+Enable **Add Python to PATH** in the Python installer.
+
+### 2. Clone and install
+
+```powershell
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+.\install.cmd -Start
+```
+
+`install.cmd` invokes the readable `install.ps1` with a process-scoped execution
+policy bypass. It does not alter the machine's permanent PowerShell policy.
+
+If the repository login does not open automatically, GitHub CLI is an
+alternative:
+
+```powershell
+winget install --id GitHub.cli --exact
+gh auth login
+gh repo clone estebanstifli/Meet2Notes
+cd Meet2Notes
+.\install.cmd -Start
+```
+
+Later launches:
+
+```powershell
+.\.venv\Scripts\meet2notes.exe
+```
+
+Useful installer choices:
+
+```powershell
+# Portable CPU installation
+.\install.cmd -AiBackend cpu
+
+# Force a CUDA llama.cpp wheel. Python 3.12 is required.
+.\install.cmd -AiBackend cuda
+
+# Install the app now but postpone the ~1.2 GiB model download.
+.\install.cmd -Models none
+
+# Replace an existing CPU/GPU llama.cpp build with the selected backend.
+.\install.cmd -AiBackend cuda -ReinstallAiRuntime
+
+# Development tools plus immediate launch.
+.\install.cmd -Dev -Start
+```
+
+The default `-AiBackend auto` uses a compatible CUDA wheel when an NVIDIA GPU
+and Python 3.10-3.12 are available; otherwise it safely uses CPU.
+
+## macOS
+
+These instructions support Apple Silicon and Intel Macs.
+
+### 1. Install the command-line prerequisites
+
+Install Homebrew if necessary:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Then install Git, Python, FFmpeg, and PortAudio:
+
+```bash
+brew install git python@3.12 ffmpeg portaudio
+git --version
+python3.12 --version
+ffmpeg -version
+```
+
+### 2. Clone and install
+
+```bash
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+chmod +x install.sh
+./install.sh --start
+```
+
+The default installer requests a Metal llama.cpp wheel and falls back to CPU if
+that wheel is unavailable for the Mac or Python version.
+
+Later launches:
+
+```bash
+.venv/bin/meet2notes
+```
+
+To force or replace a backend:
+
+```bash
+./install.sh --ai-backend cpu
+./install.sh --ai-backend metal --reinstall-ai-runtime
+```
+
+## Ubuntu or Debian
+
+### 1. Install native prerequisites
+
+```bash
+sudo apt update
+sudo apt install -y \
+  git python3 python3-venv python3-dev \
+  ffmpeg portaudio19-dev libsndfile1 \
+  build-essential cmake
+```
+
+Python 3.12 is preferred when your distribution provides it. Python 3.11 or
+3.13 can also run Meet2Notes.
+
+### 2. Clone and install
+
+```bash
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+chmod +x install.sh
+./install.sh --start
+```
+
+For NVIDIA CUDA with a compatible driver and Python 3.10-3.12:
+
+```bash
+nvidia-smi
+./install.sh --ai-backend cuda --reinstall-ai-runtime
+```
+
+The CUDA toolkit is not required for the prebuilt wheel, although the installed
+NVIDIA driver must support its CUDA runtime. If installation fails in automatic
+mode, the script falls back to CPU.
+
+## Fedora
+
+Install the prerequisites using the package repositories configured on the
+machine:
+
+```bash
+sudo dnf install -y \
+  git python3 python3-devel \
+  ffmpeg portaudio-devel libsndfile \
+  gcc-c++ cmake
+```
+
+Then:
+
+```bash
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+chmod +x install.sh
+./install.sh --start
+```
+
+Some Fedora installations require RPM Fusion before the full FFmpeg package is
+available.
+
+## Arch Linux
+
+```bash
+sudo pacman -S --needed \
+  git python ffmpeg portaudio libsndfile base-devel cmake
+git clone https://github.com/estebanstifli/Meet2Notes.git
+cd Meet2Notes
+chmod +x install.sh
+./install.sh --start
+```
+
+## What the installer changes
+
+The installers:
+
+1. Reuse or create `.venv` inside the cloned project.
+2. Install Python packages only in that environment.
+3. Detect the operating system and a compatible llama.cpp backend.
+4. Reuse FFmpeg/FFprobe from `PATH`, or try the normal package manager when
+   either tool is missing.
+5. Download and validate the selected AI models in the private application data
+   directory.
+6. Run `pip check` and print an environment report.
+
+They do not install a background service, change the permanent PowerShell
+execution policy, upload meeting data, or copy models into the Git repository.
+
+## Where models come from
+
+Model weights are not stored in the Meet2Notes repository or GitHub release.
+They are downloaded directly from their upstream publishers:
+
+| Purpose | Default files | Upstream |
+|---|---|---|
+| Transcription | Faster Whisper `small` | `Systran/faster-whisper-small` on Hugging Face |
+| Speaker segmentation | Pyannote 3.0 ONNX INT8 | `k2-fsa/sherpa-onnx` GitHub Releases |
+| Speaker embeddings | 3D-Speaker ONNX | `k2-fsa/sherpa-onnx` GitHub Releases |
+| Summaries | LFM2.5 1.2B Q4_K_M GGUF | `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` on Hugging Face |
+
+The `.gitignore` explicitly rejects `.gguf`, `.onnx`, common media files,
+databases, model directories, logs, and `.env` files.
+
+Default model locations:
+
+- Windows: `%LOCALAPPDATA%\Meet2Notes\models`
+- macOS: `~/Library/Application Support/Meet2Notes/models`
+- Linux: `~/.local/share/Meet2Notes/models`
+
+Existing LocalMeet2Resume installations continue using the historical data
+directory automatically so database recording paths do not break.
+
+## What happens when something already exists
+
+| Existing component | Installer behavior |
+|---|---|
+| `.venv` | Reused. Required package versions are checked and installed only when needed. |
+| Python packages | Reused when they satisfy the declared version range; global Python packages are untouched. |
+| FFmpeg and FFprobe | The first pair found on `PATH` is reused and its path/version is reported. |
+| Only FFmpeg or only FFprobe | Treated as incomplete; the installer tries to install the complete FFmpeg distribution. |
+| Whisper model | Hugging Face's local cache is reused; missing files are downloaded. |
+| sherpa-onnx model pair | Existing required ONNX files are reused and loaded to verify them. |
+| LFM2.5 GGUF | The existing file is reused and loaded to verify it. |
+| Interrupted download | Temporary/partial data is not treated as an installed model; the next run retries or resumes through the upstream downloader. |
+| Existing llama.cpp runtime | Reused by default. Use `-ReinstallAiRuntime` or `--reinstall-ai-runtime` only when changing CPU/GPU backend. |
+| Existing Meet2Notes database | Preserved. Installers never delete meetings, recordings, settings, or models. |
+
+Models installed elsewhere on the computer are not assumed to be compatible and
+are not scanned automatically. Whisper and diarization use Meet2Notes' managed
+model directory. A compatible GGUF stored elsewhere can be selected explicitly
+with **Local model path** in Settings.
+
+If a managed model file exists but is corrupt, model verification stops with an
+error instead of silently overwriting user data. Remove only that failed model
+from the model directory and rerun `meet2notes-models` to download a clean copy.
+
+If several FFmpeg installations exist, command lookup order (`PATH`) decides
+which one is used. You can select a specific executable at runtime:
+
+```powershell
+meet2notes --ffmpeg-path "C:\Tools\ffmpeg\bin\ffmpeg.exe"
+```
+
+```bash
+meet2notes --ffmpeg-path /opt/ffmpeg/bin/ffmpeg
+```
+
+FFprobe must be next to that custom FFmpeg executable with the matching platform
+suffix.
+
+## Updating an existing checkout
+
+Stop Meet2Notes, then:
+
+```bash
+git pull --ff-only
+```
+
+Windows:
+
+```powershell
+.\install.cmd
+```
+
+macOS/Linux:
+
+```bash
+./install.sh
+```
+
+The same environment and model cache are reused. This makes upgrades much
+smaller than first installation.
+
+## Troubleshooting
+
+### The repository is private
+
+Run `gh auth login`, verify that the account has access, and clone using
+`gh repo clone estebanstifli/Meet2Notes`.
+
+### PowerShell blocks the script
+
+Use `install.cmd`. Its bypass applies only to that installer process. Do not
+change the machine-wide execution policy.
+
+### `python -m venv` is unavailable on Linux
+
+Install the distribution's `python3-venv` package, remove only the incomplete
+`.venv` directory, and rerun `./install.sh`.
+
+### FFmpeg was installed but is not detected
+
+Open a new terminal so the updated `PATH` is loaded. Check both:
+
+```bash
+ffmpeg -version
+ffprobe -version
+```
+
+### A different AI backend is wanted
+
+The installer intentionally keeps an already working llama.cpp package. Request
+replacement explicitly:
+
+```powershell
+.\install.cmd -AiBackend cuda -ReinstallAiRuntime
+```
+
+```bash
+./install.sh --ai-backend cuda --reinstall-ai-runtime
+```

--- a/docs/competitive-analysis-meetily.md
+++ b/docs/competitive-analysis-meetily.md
@@ -1,0 +1,60 @@
+# Competitive review: Meetily
+
+Reviewed repository:
+[`Zackriya-Solutions/meetily`](https://github.com/Zackriya-Solutions/meetily)
+and its public README/build documentation on 2026-07-26.
+
+## What Meetily presents well
+
+- A strong visual hero, demo animation, screenshots, badges, release link, and
+  community links establish the product before technical details.
+- Its privacy-first promise is repeated consistently and tied to concrete
+  enterprise use cases.
+- The README separates benefits, feature demonstrations, architecture,
+  installation, contribution, and licensing.
+- Prebuilt Windows/macOS downloads give non-developers a short path to first use.
+- The Linux documentation explains GPU detection order and CPU fallback in
+  unusually good detail.
+
+## Gaps and inconsistencies
+
+- Public links and clone commands still mix the `meetily` and historical
+  `meeting-minutes` repository names.
+- The README's Linux quick start is not a complete installation from zero.
+  `build-gpu.sh` requires Node, a package manager, Rust/Cargo, CMake, Tauri
+  dependencies, and platform libraries that the short block does not install.
+- The Linux build script hard-codes CUDA architecture `75` before detection,
+  while the documentation tells users to select an architecture for their GPU.
+- Platform claims are broader than the binary release path: the current release
+  offers Windows and macOS assets, while Linux users compile from source.
+- Speaker diarization is described differently across repository metadata,
+  community feature lists, and the PRO promotion.
+- A large PRO promotion interrupts the open-source product story and makes the
+  README feel less focused.
+
+## Meet2Notes positioning
+
+Meet2Notes should keep Meetily's clarity and visual product storytelling while
+making installation materially simpler:
+
+- One Python environment instead of a Node + Rust + Tauri compilation toolchain.
+- Human-readable `.cmd`, PowerShell, and Bash installers instead of depending on
+  an unsigned executable.
+- Complete clone-to-launch instructions for Windows, macOS, and major Linux
+  families.
+- Explicit idempotency rules for environments, FFmpeg, packages, and models.
+- Local diarization in the community application today.
+- A precise distinction between packages stored in Git and model weights
+  downloaded from upstream publishers.
+
+## Recommended product follow-ups
+
+1. Add a clean demo GIF recorded against synthetic meeting content.
+2. Add two or three annotated screenshots for capture, live transcript, and AI
+   Settings.
+3. Publish signed installers only after a repeatable release/signing pipeline is
+   available; keep source scripts as the transparent fallback.
+4. Add benchmark tables for latency, RAM/VRAM, and transcription speed on common
+   CPU/GPU configurations.
+5. Keep the README focused on the product and move deep troubleshooting into
+   installation documentation.

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+where powershell.exe >nul 2>nul
+if errorlevel 1 (
+    echo Meet2Notes requires Windows PowerShell 5.1 or PowerShell 7.
+    exit /b 1
+)
+
+echo Starting the Meet2Notes installer...
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass ^
+    -File "%~dp0install.ps1" %*
+set "MEET2NOTES_EXIT=%ERRORLEVEL%"
+
+if not "%MEET2NOTES_EXIT%"=="0" (
+    echo.
+    echo Meet2Notes installation failed with exit code %MEET2NOTES_EXIT%.
+)
+
+exit /b %MEET2NOTES_EXIT%

--- a/install.ps1
+++ b/install.ps1
@@ -18,6 +18,7 @@ param(
     [string]$WhisperModel = "small",
 
     [switch]$SkipFfmpeg,
+    [switch]$ReinstallAiRuntime,
     [switch]$Dev,
     [switch]$Start
 )
@@ -57,18 +58,58 @@ function Get-BootstrapPython {
 
     $Python = Get-Command python -ErrorAction SilentlyContinue
     if ($Python) {
-        return @($Python.Source)
+        & $Python.Source -c "import sys; raise SystemExit(sys.version_info < (3, 11))" *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return @($Python.Source)
+        }
     }
-    throw "Python 3.11+ was not found. Install it from https://www.python.org/downloads/"
+
+    $Winget = Get-Command winget -ErrorAction SilentlyContinue
+    if ($Winget) {
+        Write-Step "Python 3.12 was not found; installing it with winget"
+        & $Winget.Source install --id Python.Python.3.12 --exact --source winget `
+            --accept-package-agreements --accept-source-agreements
+        if ($LASTEXITCODE -eq 0) {
+            $InstalledPython = Join-Path $env:LOCALAPPDATA `
+                "Programs\Python\Python312\python.exe"
+            if (Test-Path -LiteralPath $InstalledPython) {
+                return @($InstalledPython)
+            }
+            $RefreshedLauncher = Get-Command py -ErrorAction SilentlyContinue
+            if ($RefreshedLauncher) {
+                return @($RefreshedLauncher.Source, "-3.12")
+            }
+        }
+    }
+    throw (
+        "Python 3.11+ was not found. Install Python 3.12 from " +
+        "https://www.python.org/downloads/ and run install.cmd again."
+    )
 }
 
 function Install-Ffmpeg {
-    if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
-        Write-Host "FFmpeg is already available."
-        return
+    $Ffmpeg = Get-Command ffmpeg -ErrorAction SilentlyContinue
+    $Ffprobe = Get-Command ffprobe -ErrorAction SilentlyContinue
+    if ($Ffmpeg -and $Ffprobe) {
+        $FfmpegOutput = & $Ffmpeg.Source -version 2>$null
+        $FfmpegWorks = $LASTEXITCODE -eq 0
+        $FfprobeOutput = & $Ffprobe.Source -version 2>$null
+        $FfprobeWorks = $LASTEXITCODE -eq 0
+        if ($FfmpegWorks -and $FfprobeWorks) {
+            $FfmpegVersion = $FfmpegOutput | Select-Object -First 1
+            $FfprobeVersion = $FfprobeOutput | Select-Object -First 1
+            Write-Host "FFmpeg is already available: $FfmpegVersion"
+            Write-Host "FFprobe is already available: $FfprobeVersion"
+            Write-Host "Using: $($Ffmpeg.Source)"
+            return
+        }
+        Write-Warning "FFmpeg/FFprobe were found but did not pass a version check."
     }
     if ($SkipFfmpeg) {
-        Write-Warning "FFmpeg was not found. Media import will require it later."
+        Write-Warning (
+            "FFmpeg and FFprobe were not both found. Media import will " +
+            "require them later."
+        )
         return
     }
 
@@ -77,11 +118,16 @@ function Install-Ffmpeg {
         Write-Warning "FFmpeg was not found and winget is unavailable. Install FFmpeg manually."
         return
     }
-    Write-Step "Installing FFmpeg with winget"
+    Write-Step "FFmpeg/FFprobe were not both found; installing FFmpeg with winget"
     & $Winget.Source install --id Gyan.FFmpeg --exact --source winget `
         --accept-package-agreements --accept-source-agreements
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "FFmpeg installation did not complete. Meet2Notes itself is installed."
+    } else {
+        Write-Host (
+            "FFmpeg was installed. If this terminal cannot see it yet, open " +
+            "a new terminal before starting Meet2Notes."
+        )
     }
 }
 
@@ -148,8 +194,15 @@ $LlamaIndex = if ($ResolvedBackend -eq "cuda") {
     "https://abetlen.github.io/llama-cpp-python/whl/cpu"
 }
 Write-Host "llama.cpp backend: $ResolvedBackend"
-& $EnvironmentPython -m pip install "llama-cpp-python>=0.3.8,<1" `
-    --extra-index-url $LlamaIndex
+$LlamaArguments = @(
+    "-m", "pip", "install",
+    "llama-cpp-python>=0.3.8,<1",
+    "--extra-index-url", $LlamaIndex
+)
+if ($ReinstallAiRuntime) {
+    $LlamaArguments += @("--force-reinstall", "--no-cache-dir")
+}
+& $EnvironmentPython @LlamaArguments
 if ($LASTEXITCODE -ne 0 -and $AiBackend -eq "auto" -and $ResolvedBackend -eq "cuda") {
     Write-Warning "CUDA wheel installation failed; falling back to the portable CPU wheel."
     Invoke-Checked $EnvironmentPython @(
@@ -185,6 +238,7 @@ Invoke-Checked $EnvironmentPython @("scripts/check_environment.py")
 Write-Host ""
 Write-Host "Meet2Notes is ready." -ForegroundColor Green
 Write-Host "Run: .\.venv\Scripts\meet2notes.exe"
+Write-Host "Re-running install.cmd safely reuses the environment and downloaded models."
 
 if ($Start) {
     & (Join-Path $EnvironmentRoot "Scripts\meet2notes.exe")

--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,46 @@ INSTALLER_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 ENVIRONMENT_ROOT="${INSTALLER_ROOT}/.venv"
 MODELS="all"
 WHISPER_MODEL="small"
+AI_BACKEND="auto"
+REINSTALL_AI_RUNTIME="false"
 DEV="false"
 START="false"
 
+usage() {
+  cat <<'EOF'
+Usage: ./install.sh [options]
+
+Options:
+  --ai-backend auto|cpu|cuda|metal
+                                 Select the llama.cpp backend (default: auto)
+  --reinstall-ai-runtime         Replace an existing llama.cpp installation
+  --no-models                    Do not download AI models during setup
+  --whisper-model MODEL          Select tiny/base/small/medium/large-v3/etc.
+  --dev                          Install development tools
+  --start                        Launch Meet2Notes after installation
+  -h, --help                     Show this help
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
     --no-models) MODELS="none" ;;
+    --ai-backend)
+      shift
+      AI_BACKEND="${1:?Missing AI backend (auto, cpu, cuda, or metal)}"
+      case "${AI_BACKEND}" in
+        auto|cpu|cuda|metal) ;;
+        *)
+          echo "Unsupported AI backend: ${AI_BACKEND}" >&2
+          exit 2
+          ;;
+      esac
+      ;;
+    --reinstall-ai-runtime) REINSTALL_AI_RUNTIME="true" ;;
     --whisper-model)
       shift
       WHISPER_MODEL="${1:?Missing Whisper model name}"
@@ -64,16 +98,48 @@ step "Installing Meet2Notes and native audio/AI runtimes"
 
 PYTHON_MINOR="$("${PYTHON}" -c 'import sys; print(sys.version_info.minor)')"
 LLAMA_INDEX="https://abetlen.github.io/llama-cpp-python/whl/cpu"
-if [[ "$(uname -s)" == "Darwin" ]]; then
+RESOLVED_AI_BACKEND="${AI_BACKEND}"
+if [[ "${RESOLVED_AI_BACKEND}" == "auto" && "$(uname -s)" == "Darwin" ]]; then
+  RESOLVED_AI_BACKEND="metal"
+elif [[ "${RESOLVED_AI_BACKEND}" == "auto" ]] \
+  && command -v nvidia-smi >/dev/null 2>&1 \
+  && [[ "${PYTHON_MINOR}" -le 12 ]]; then
+  RESOLVED_AI_BACKEND="cuda"
+elif [[ "${RESOLVED_AI_BACKEND}" == "auto" ]]; then
+  RESOLVED_AI_BACKEND="cpu"
+fi
+
+if [[ "${RESOLVED_AI_BACKEND}" == "cuda" && "${PYTHON_MINOR}" -gt 12 ]]; then
+  echo "The prebuilt llama.cpp CUDA wheel requires Python 3.10-3.12." >&2
+  exit 1
+fi
+if [[ "${RESOLVED_AI_BACKEND}" == "metal" && "$(uname -s)" != "Darwin" ]]; then
+  echo "The Metal backend is available only on macOS." >&2
+  exit 1
+fi
+
+if [[ "${RESOLVED_AI_BACKEND}" == "metal" ]]; then
   LLAMA_INDEX="https://abetlen.github.io/llama-cpp-python/whl/metal"
-elif command -v nvidia-smi >/dev/null 2>&1 && [[ "${PYTHON_MINOR}" -le 12 ]]; then
+elif [[ "${RESOLVED_AI_BACKEND}" == "cuda" ]]; then
   LLAMA_INDEX="https://abetlen.github.io/llama-cpp-python/whl/cu124"
 fi
-if ! "${PYTHON}" -m pip install "llama-cpp-python>=0.3.8,<1" \
-  --extra-index-url "${LLAMA_INDEX}"; then
-  echo "Accelerated llama.cpp wheel unavailable; using the portable CPU wheel."
-  "${PYTHON}" -m pip install --force-reinstall "llama-cpp-python>=0.3.8,<1" \
-    --extra-index-url "https://abetlen.github.io/llama-cpp-python/whl/cpu"
+echo "llama.cpp backend: ${RESOLVED_AI_BACKEND}"
+LLAMA_ARGUMENTS=(
+  -m pip install "llama-cpp-python>=0.3.8,<1"
+  --extra-index-url "${LLAMA_INDEX}"
+)
+if [[ "${REINSTALL_AI_RUNTIME}" == "true" ]]; then
+  LLAMA_ARGUMENTS+=(--force-reinstall --no-cache-dir)
+fi
+if ! "${PYTHON}" "${LLAMA_ARGUMENTS[@]}"; then
+  if [[ "${AI_BACKEND}" == "auto" && "${RESOLVED_AI_BACKEND}" != "cpu" ]]; then
+    echo "Accelerated llama.cpp wheel unavailable; using the portable CPU wheel."
+    "${PYTHON}" -m pip install --force-reinstall "llama-cpp-python>=0.3.8,<1" \
+      --extra-index-url "https://abetlen.github.io/llama-cpp-python/whl/cpu"
+  else
+    echo "llama-cpp-python could not be installed for '${RESOLVED_AI_BACKEND}'." >&2
+    exit 1
+  fi
 fi
 
 if [[ "${DEV}" == "true" ]]; then
@@ -81,7 +147,10 @@ if [[ "${DEV}" == "true" ]]; then
   "${PYTHON}" -m pip install -e ".[dev]"
 fi
 
-if ! command -v ffmpeg >/dev/null 2>&1; then
+if ! command -v ffmpeg >/dev/null 2>&1 \
+  || ! command -v ffprobe >/dev/null 2>&1 \
+  || ! ffmpeg -version >/dev/null 2>&1 \
+  || ! ffprobe -version >/dev/null 2>&1; then
   echo
   echo "FFmpeg is required for imported media."
   if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
@@ -109,6 +178,7 @@ step "Verifying the installation"
 
 printf "\n\033[32mMeet2Notes is ready.\033[0m\n"
 echo "Run: .venv/bin/meet2notes"
+echo "Re-running install.sh safely reuses the environment and downloaded models."
 
 if [[ "${START}" == "true" ]]; then
   "${ENVIRONMENT_ROOT}/bin/meet2notes"

--- a/scripts/check_environment.py
+++ b/scripts/check_environment.py
@@ -1,19 +1,73 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import platform
 import shutil
+import subprocess
 import sys
+from pathlib import Path
+from typing import Any
+
+
+def command_report(name: str) -> dict[str, str | None]:
+    executable = shutil.which(name)
+    version: str | None = None
+    if executable:
+        try:
+            completed = subprocess.run(
+                [executable, "-version"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            output = completed.stdout or completed.stderr
+            version = output.splitlines()[0] if output else None
+        except (OSError, subprocess.SubprocessError):
+            version = None
+    return {"path": executable, "version": version}
+
+
+def package_available(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
 
 
 def main() -> None:
-    report = {
+    report: dict[str, Any] = {
         "python": sys.version.split()[0],
         "python_supported": sys.version_info >= (3, 11),
         "platform": platform.platform(),
-        "ffmpeg": shutil.which("ffmpeg"),
-        "ffprobe": shutil.which("ffprobe"),
+        "executables": {
+            "ffmpeg": command_report("ffmpeg"),
+            "ffprobe": command_report("ffprobe"),
+        },
+        "python_packages": {
+            "faster_whisper": package_available("faster_whisper"),
+            "sherpa_onnx": package_available("sherpa_onnx"),
+            "llama_cpp": package_available("llama_cpp"),
+            "pyaudiowpatch": package_available("pyaudiowpatch"),
+            "sounddevice": package_available("sounddevice"),
+        },
     }
+    try:
+        from local_meeting_ai.config import AppSettings
+        from local_meeting_ai.paths import AppPaths
+
+        paths = AppPaths.from_settings(AppSettings())
+        report["data_directory"] = str(paths.root)
+        report["models_directory"] = str(paths.models)
+        existing_path = next(
+            (path for path in (paths.root, paths.root.parent) if path.exists()),
+            Path.cwd(),
+        )
+        report["free_space_gib"] = round(
+            shutil.disk_usage(existing_path).free / (1024**3),
+            2,
+        )
+    except (ImportError, OSError, ValueError):
+        report["data_directory"] = None
+        report["models_directory"] = None
     print(json.dumps(report, indent=2))
 
 

--- a/src/local_meeting_ai/model_setup.py
+++ b/src/local_meeting_ai/model_setup.py
@@ -64,17 +64,32 @@ async def install_models(
     print(f"Meet2Notes model directory: {paths.models}")
 
     if "whisper" in requested:
-        print(f"[1/3] Downloading and verifying Faster Whisper '{whisper_model}'...")
+        whisper_engine = FasterWhisperEngine(paths.models)
+        cached = whisper_model in whisper_engine.capability().get(
+            "installed_models",
+            [],
+        )
+        whisper_engine.shutdown()
+        action = "Verifying cached" if cached else "Downloading and verifying"
+        print(f"[1/3] {action} Faster Whisper '{whisper_model}'...")
         await _install_whisper(paths, whisper_model)
         print("      Faster Whisper is ready.")
 
     if "diarization" in requested:
-        print("[2/3] Downloading and verifying sherpa-onnx diarization models...")
+        diarization_engine = SherpaOnnxDiarizationEngine(paths.models)
+        cached = bool(diarization_engine.capability().get("installed"))
+        diarization_engine.shutdown()
+        action = "Verifying cached" if cached else "Downloading and verifying"
+        print(f"[2/3] {action} sherpa-onnx diarization models...")
         await _install_diarization(paths)
         print("      Speaker diarization is ready.")
 
     if "summary" in requested:
-        print("[3/3] Downloading and verifying LFM2.5 1.2B Q4_K_M...")
+        summary_engine = LlamaCppSummaryEngine(paths.models)
+        cached = bool(summary_engine.capability().get("installed"))
+        summary_engine.shutdown()
+        action = "Verifying cached" if cached else "Downloading and verifying"
+        print(f"[3/3] {action} LFM2.5 1.2B Q4_K_M...")
         await _install_summary(paths)
         print("      Local meeting summaries are ready.")
 


### PR DESCRIPTION
## What changed

- adds clone-to-launch instructions for Windows, macOS, Ubuntu/Debian, Fedora, and Arch Linux
- adds a transparent `install.cmd` entry point for Windows
- documents private-repository authentication, CPU/CUDA/Metal selection, updates, and troubleshooting
- documents upstream model provenance and confirms that model weights are not committed to this repository
- makes FFmpeg/FFprobe detection functional and reports the selected paths and versions
- makes llama.cpp backend replacement explicit while preserving compatible existing installations
- reports cached model reuse and expands the environment diagnostics
- records a focused competitive review of Meetily's README and build flow

## Why

The previous README began inside an already-cloned checkout and did not fully explain prerequisites, private GitHub authentication, model storage, or behavior when dependencies already existed. The new flow provides a readable script-based alternative to unsigned installers and makes repeated setup safe and predictable.

## Validation

- `ruff check .`
- `mypy src`
- `pytest` — 23 passed
- PowerShell parser validation for `install.ps1`
- `bash -n install.sh` and `./install.sh --help`
- real Windows install through `install.cmd -Models none -SkipFfmpeg -AiBackend cpu`
- cached verification/load of Faster Whisper small, sherpa-onnx diarization, and LFM2.5 Q4_K_M
- `pip check`
- staged secret scan and `git diff --check`
